### PR TITLE
Deixando o logo do insper no canto inferior direito todo dentro do slide

### DIFF
--- a/beamerinnerthemeinsper.sty
+++ b/beamerinnerthemeinsper.sty
@@ -41,7 +41,7 @@
     \draw[fill=insperDarkRed] (-1in,-\paperheight) rectangle
 (\paperwidth,\paperheight);
 \end{tikzpicture}
-    \begin{beamercolorbox}[wd=\paperwidth, sep=10pt, center]{section title}
+    \begin{beamercolorbox}[wd=\paperwidth, sep=12pt, center]{section title}
     
     \usebeamerfont{frametitle}\insertsection\par
     

--- a/beamerouterthemeinsper.sty
+++ b/beamerouterthemeinsper.sty
@@ -10,7 +10,7 @@
     \begingroup
     \begin{beamercolorbox}[right, sep=5pt]{default}
     \ifnum\thepage>1\relax
-    \includegraphics[width=0.1\paperwidth]{img/Insper-positivo}
+    \includegraphics[width=0.05\paperwidth]{img/Insper-positivo}
     \fi
     \end{beamercolorbox}
     \endgroup


### PR DESCRIPTION
Alterações feitas para deixar o logo do Insper que fica no canto inferior direito todo dentro do slide. 